### PR TITLE
Add GOVERNANCE.md

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,83 @@
+# Governance
+
+## Overview
+
+Sequoïa is an open source project released under the GNU General Public License v3.0 (GPL-3.0).  
+Its governance follows a maintainer-led model, designed to ensure technical coherence, long-term sustainability, and openness to contributions.
+
+The goal of this governance is to balance:
+
+- a clear and consistent project vision,
+- openness to community contributions,
+- shared ownership enabled by the GPL license.
+
+## Maintainers
+
+Maintainers are responsible for the overall direction, integrity, and quality of the project.
+
+Their responsibilities include:
+
+- defining and guiding the project roadmap,
+- reviewing and merging pull requests,
+- ensuring code quality and consistency,
+- managing releases,
+- maintaining documentation,
+- facilitating community contributions.
+
+Maintainers act in the best interest of the project and its users.
+
+## Contributors
+
+Anyone can contribute to Sequoïa, including:
+
+- bug reports,
+- feature suggestions,
+- documentation improvements,
+- code contributions,
+- testing and feedback.
+
+Contributors help shape the evolution of the project through proposals and collaboration with maintainers.
+
+## Decision Process
+
+Decisions are made transparently through GitHub issues and pull requests.
+
+General principles:
+
+- technical discussions are public,
+- proposals are evaluated on their technical merit and alignment with project goals,
+- maintainers make final decisions when necessary to ensure coherence.
+
+Consensus is encouraged whenever possible.
+
+## Open Source and Shared Sovereignty
+
+SequoiApp and so Rsequoia2 is licensed under GPL-3.0, ensuring that:
+
+- the source code remains open and accessible,
+- anyone can use, study, modify, and redistribute the software,
+- improvements remain available to the community.
+
+This model guarantees long-term sustainability and shared sovereignty over the tool.
+
+## Becoming a Maintainer
+
+Contributors who demonstrate sustained, high-quality contributions and alignment with the project goals may be invited to become maintainers.
+
+This decision is made collectively by existing maintainers.
+
+## Transparency
+
+All development occurs publicly via GitHub:
+
+- Issues: bug reports, discussions, feature requests
+- Pull Requests: proposed changes
+- Releases: versioned software updates
+
+This ensures transparency and traceability of decisions.
+
+## Code of Conduct
+
+All participants are expected to act respectfully and constructively.
+
+Maintainers reserve the right to moderate discussions to preserve a healthy and productive environment.


### PR DESCRIPTION
@mucau @Balrog329 @jeanlumix,

Voici une proposition classique d'organisation de la gouvernance d'un projet open-source par les mainteneurs.

Est-ce que cela vous va ? Si oui, il faudra également l"intégrer à Qsequoia2.

En réponse à [#3](https://github.com/SequoiApp/.gouv/issues/3)